### PR TITLE
 feat: fetch bike station data on utils

### DIFF
--- a/src/components/charts/BikeStationChart.tsx
+++ b/src/components/charts/BikeStationChart.tsx
@@ -117,8 +117,7 @@ export default function BikeStationChart({
               tickMargin={8}
               minTickGap={32}
               tickFormatter={(value) => {
-                const date = new Date(value);
-                return date.toLocaleDateString('fr-FR', {
+                return new Date(value).toLocaleDateString('fr-FR', {
                   month: 'short',
                   day: 'numeric',
                   hour: 'numeric',
@@ -129,7 +128,7 @@ export default function BikeStationChart({
             <ChartTooltip
               content={
                 <ChartTooltipContent
-                  className="w-[150px]"
+                  className="w-48"
                   nameKey="free_bikes"
                   labelFormatter={(value) => {
                     return new Date(value).toLocaleDateString('fr-FR', {

--- a/src/components/charts/BikeStationChart.tsx
+++ b/src/components/charts/BikeStationChart.tsx
@@ -121,6 +121,8 @@ export default function BikeStationChart({
                 return date.toLocaleDateString('fr-FR', {
                   month: 'short',
                   day: 'numeric',
+                  hour: 'numeric',
+                  minute: 'numeric',
                 });
               }}
             />
@@ -134,6 +136,8 @@ export default function BikeStationChart({
                       month: 'short',
                       day: 'numeric',
                       year: 'numeric',
+                      hour: 'numeric',
+                      minute: 'numeric',
                     });
                   }}
                 />

--- a/src/components/charts/BikeStationChart.tsx
+++ b/src/components/charts/BikeStationChart.tsx
@@ -17,10 +17,10 @@ import {
   ChartTooltipContent,
 } from '@/components/ui/chart';
 
-import { BikeStation } from '@prisma/client';
 import { BikeStationData } from '../tabs/BikeTab';
 
 import { useSocket } from '@/context/SocketProvider';
+import { fetchBikeStationData } from '@/lib/bikes.utils';
 
 const chartConfig = {
   free_bikes: {
@@ -57,29 +57,7 @@ export default function BikeStationChart({
     }
 
     const refreshData = async () => {
-      const data = await fetch('http://localhost:3000/api/bikes/', {
-        cache: 'no-store',
-      });
-      const bikes = await data.json();
-      const bikeStationData: BikeStationData[] = [];
-      const bikeStationUniqueDate: string[] = [];
-      bikes.forEach((bike: BikeStation) => {
-        const date = bike.timestamp.toString().split('T')[0];
-        if (!bikeStationUniqueDate.includes(date)) {
-          bikeStationUniqueDate.push(date);
-          bikeStationData.push({
-            date: date,
-            free_bikes: bike.free_bikes,
-            empty_slots: bike.empty_slots,
-          });
-        } else {
-          const dateIndex = bikeStationData.findIndex(
-            (data) => data.date === date,
-          );
-          bikeStationData[dateIndex].free_bikes += bike.free_bikes;
-          bikeStationData[dateIndex].empty_slots += bike.empty_slots;
-        }
-      });
+      const bikeStationData = await fetchBikeStationData();
       setDataState(bikeStationData);
     };
 

--- a/src/components/charts/BikeStationChart.tsx
+++ b/src/components/charts/BikeStationChart.tsx
@@ -45,8 +45,8 @@ export default function BikeStationChart({
 
   const totalData = React.useMemo(
     () => ({
-      free_bikes: dataState.reduce((acc, curr) => acc + curr.free_bikes, 0),
-      empty_slots: dataState.reduce((acc, curr) => acc + curr.empty_slots, 0),
+      free_bikes: dataState[dataState.length - 1].free_bikes,
+      empty_slots: dataState[dataState.length - 1].empty_slots,
     }),
     [dataState],
   );

--- a/src/components/tabs/BikeTab.tsx
+++ b/src/components/tabs/BikeTab.tsx
@@ -3,6 +3,7 @@ import BikeStationChart from '@/components/charts/BikeStationChart';
 
 import { HeatLatLngTuple } from 'leaflet';
 import { BikeStation } from '@prisma/client';
+import { fetchBikeStationData } from '@/lib/bikes.utils';
 
 export interface BikeStationData {
   date: string;
@@ -16,24 +17,7 @@ export default async function BikeTab() {
   });
   const bikes = await data.json();
 
-  // Statistiques sur les stations
-  const bikeStationData: BikeStationData[] = [];
-  const bikeStationUniqueDate: string[] = [];
-  bikes.forEach((bike: BikeStation) => {
-    const date = bike.timestamp.toString().split('T')[0];
-    if (!bikeStationUniqueDate.includes(date)) {
-      bikeStationUniqueDate.push(date);
-      bikeStationData.push({
-        date: date,
-        free_bikes: bike.free_bikes,
-        empty_slots: bike.empty_slots,
-      });
-    } else {
-      const dateIndex = bikeStationData.findIndex((data) => data.date === date);
-      bikeStationData[dateIndex].free_bikes += bike.free_bikes;
-      bikeStationData[dateIndex].empty_slots += bike.empty_slots;
-    }
-  });
+  const bikeStationData = await fetchBikeStationData();
 
   // Carte des stations
   const bikeStationHeatmap: HeatLatLngTuple[] = [];

--- a/src/lib/bikes.utils.ts
+++ b/src/lib/bikes.utils.ts
@@ -1,27 +1,42 @@
 import { BikeStationData } from '@/components/tabs/BikeTab';
-import { BikeStation } from '@prisma/client';
+import { BikeStation, BikeStationHistory } from '@prisma/client';
 
 export const fetchBikeStationData = async () => {
   const data = await fetch('http://localhost:3000/api/bikes/', {
     cache: 'no-store',
   });
   const bikes = await data.json();
+
   const bikeStationData: BikeStationData[] = [];
   const bikeStationUniqueDate: string[] = [];
+
   bikes.forEach((bike: BikeStation) => {
-    const date = bike.timestamp.toString().split(':').slice(0, 2).join(':'); // Extract date and time up to minutes
-    if (!bikeStationUniqueDate.includes(date)) {
-      bikeStationUniqueDate.push(date);
-      bikeStationData.push({
-        date: date,
-        free_bikes: bike.free_bikes,
-        empty_slots: bike.empty_slots,
-      });
-    } else {
-      const dateIndex = bikeStationData.findIndex((data) => data.date === date);
-      bikeStationData[dateIndex].free_bikes += bike.free_bikes;
-      bikeStationData[dateIndex].empty_slots += bike.empty_slots;
-    }
+    bike.BikeStationHistory.forEach((bikeHistory: BikeStationHistory) => {
+      const date = bikeHistory.timestamp
+        .toString()
+        .split(':')
+        .slice(0, 2)
+        .join(':');
+      if (!bikeStationUniqueDate.includes(date)) {
+        bikeStationUniqueDate.push(date);
+        bikeStationData.push({
+          date: date,
+          free_bikes: bikeHistory.free_bikes,
+          empty_slots: bikeHistory.empty_slots,
+        });
+      } else {
+        const dateIndex = bikeStationData.findIndex(
+          (data) => data.date === date,
+        );
+        bikeStationData[dateIndex].free_bikes += bikeHistory.free_bikes;
+        bikeStationData[dateIndex].empty_slots += bikeHistory.empty_slots;
+      }
+    });
   });
+
+  bikeStationData.sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  );
+
   return bikeStationData;
 };

--- a/src/lib/bikes.utils.ts
+++ b/src/lib/bikes.utils.ts
@@ -1,0 +1,27 @@
+import { BikeStationData } from '@/components/tabs/BikeTab';
+import { BikeStation } from '@prisma/client';
+
+export const fetchBikeStationData = async () => {
+  const data = await fetch('http://localhost:3000/api/bikes/', {
+    cache: 'no-store',
+  });
+  const bikes = await data.json();
+  const bikeStationData: BikeStationData[] = [];
+  const bikeStationUniqueDate: string[] = [];
+  bikes.forEach((bike: BikeStation) => {
+    const date = bike.timestamp.toString().split('T')[0];
+    if (!bikeStationUniqueDate.includes(date)) {
+      bikeStationUniqueDate.push(date);
+      bikeStationData.push({
+        date: date,
+        free_bikes: bike.free_bikes,
+        empty_slots: bike.empty_slots,
+      });
+    } else {
+      const dateIndex = bikeStationData.findIndex((data) => data.date === date);
+      bikeStationData[dateIndex].free_bikes += bike.free_bikes;
+      bikeStationData[dateIndex].empty_slots += bike.empty_slots;
+    }
+  });
+  return bikeStationData;
+};

--- a/src/lib/bikes.utils.ts
+++ b/src/lib/bikes.utils.ts
@@ -8,7 +8,6 @@ export const fetchBikeStationData = async () => {
   const bikes = await data.json();
 
   const bikeStationData: BikeStationData[] = [];
-  const bikeStationUniqueDate: string[] = [];
 
   bikes.forEach((bike: BikeStation) => {
     bike.BikeStationHistory.forEach((bikeHistory: BikeStationHistory) => {
@@ -17,17 +16,16 @@ export const fetchBikeStationData = async () => {
         .split(':')
         .slice(0, 2)
         .join(':');
-      if (!bikeStationUniqueDate.includes(date)) {
-        bikeStationUniqueDate.push(date);
+
+      const dateIndex = bikeStationData.findIndex((data) => data.date === date);
+
+      if (dateIndex === -1) {
         bikeStationData.push({
           date: date,
           free_bikes: bikeHistory.free_bikes,
           empty_slots: bikeHistory.empty_slots,
         });
       } else {
-        const dateIndex = bikeStationData.findIndex(
-          (data) => data.date === date,
-        );
         bikeStationData[dateIndex].free_bikes += bikeHistory.free_bikes;
         bikeStationData[dateIndex].empty_slots += bikeHistory.empty_slots;
       }

--- a/src/lib/bikes.utils.ts
+++ b/src/lib/bikes.utils.ts
@@ -9,7 +9,7 @@ export const fetchBikeStationData = async () => {
   const bikeStationData: BikeStationData[] = [];
   const bikeStationUniqueDate: string[] = [];
   bikes.forEach((bike: BikeStation) => {
-    const date = bike.timestamp.toString().split('T')[0];
+    const date = bike.timestamp.toString().split(':').slice(0, 2).join(':'); // Extract date and time up to minutes
     if (!bikeStationUniqueDate.includes(date)) {
       bikeStationUniqueDate.push(date);
       bikeStationData.push({


### PR DESCRIPTION
# Description de la PR

- Prendre les données du total du dernier historique pour les nombres au lieu du total de tous
- Suppression de la limitation à un BikeStation unique pour les historiques
- Ajout de l'historique de la BDD et du tri chronologique
- Quelques ajustement pour le formateur de tooltip
- Affichage des stats des stations de vélos d'heures par minutes
- Fonction de fetch des données des BikeStations dans un fichier .utils